### PR TITLE
Added support for imports in python3

### DIFF
--- a/barbershop/__init__.py
+++ b/barbershop/__init__.py
@@ -18,7 +18,7 @@ from matplotlib.widgets import Slider, Button
 import glob as glob
 import pandas as pd
 
-from external_functions import *
+from .external_functions import *
 
 class open:
     def __init__(self, _core_df, _namex, _namey):


### PR DESCRIPTION
Adding relative import of external_functions in `__init__.py`. This prevents the import error `ImportError: No module named 'external_functions'` when running in python3. The change is also compatible with python2.